### PR TITLE
C15: Change the unit order in Learn to kickoff Unit 2

### DIFF
--- a/c15/paper/course.yaml
+++ b/c15/paper/course.yaml
@@ -1,23 +1,23 @@
 ---
   :Course:
-  - :Section: "About Ada"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
-  - :Section: "Unit 1"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
   - :Section: "Unit 2"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-unit-2    
-  - :Section: "Lightning Talks"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
   - :Section: "Projects"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-projects
   - :Section: "Problem-Solving Exercises (PSEs)"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-pses
+  - :Section: "Lightning Talks"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
+  - :Section: "Unit 1"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
+  - :Section: "About Ada"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
   - :Section: "Precourse"
     :Repos:
     - :Url: https://github.com/ada-developers-academy/ada-precourse-v2  

--- a/c15/rock/course.yaml
+++ b/c15/rock/course.yaml
@@ -1,23 +1,23 @@
 ---
   :Course:
-  - :Section: "About Ada"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
-  - :Section: "Unit 1"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
   - :Section: "Unit 2"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-unit-2    
-  - :Section: "Lightning Talks"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
   - :Section: "Projects"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-projects
   - :Section: "Problem-Solving Exercises (PSEs)"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-pses
+  - :Section: "Lightning Talks"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
+  - :Section: "Unit 1"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
+  - :Section: "About Ada"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
   - :Section: "Precourse"
     :Repos:
     - :Url: https://github.com/ada-developers-academy/ada-precourse-v2  

--- a/c15/scissors/course.yaml
+++ b/c15/scissors/course.yaml
@@ -3,15 +3,15 @@
   - :Section: "Unit 2"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-unit-2    
-  - :Section: "Lightning Talks"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
   - :Section: "Projects"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-projects
   - :Section: "Problem-Solving Exercises (PSEs)"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-pses
+  - :Section: "Lightning Talks"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
   - :Section: "Unit 1"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-unit-1

--- a/c15/scissors/course.yaml
+++ b/c15/scissors/course.yaml
@@ -1,11 +1,5 @@
 ---
   :Course:
-  - :Section: "About Ada"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
-  - :Section: "Unit 1"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
   - :Section: "Unit 2"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-unit-2    
@@ -18,6 +12,12 @@
   - :Section: "Problem-Solving Exercises (PSEs)"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-pses
+  - :Section: "Unit 1"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
+  - :Section: "About Ada"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
   - :Section: "Precourse"
     :Repos:
     - :Url: https://github.com/ada-developers-academy/ada-precourse-v2  

--- a/course.yaml
+++ b/course.yaml
@@ -1,20 +1,23 @@
 ---
-:Course:
-- :Section: "About Ada"
-  :Repos:
-  - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
-- :Section: "Unit 1"
-  :Repos:
-  - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
-- :Section: "Unit 2"
-  :Repos:
-  - :Url: https://github.com/Ada-Developers-Academy/core-unit-2
-- :Section: "Lightning Talks"
-  :Repos:
-  - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
-- :Section: "Projects"
-  :Repos:
-  - :Url: https://github.com/Ada-Developers-Academy/core-projects
-- :Section: "Problem-Solving Exercises (PSEs)"
-  :Repos:
-  - :Url: https://github.com/Ada-Developers-Academy/core-pses
+  :Course:
+  - :Section: "Unit 2"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-unit-2    
+  - :Section: "Projects"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-projects
+  - :Section: "Problem-Solving Exercises (PSEs)"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-pses
+  - :Section: "Lightning Talks"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
+  - :Section: "Unit 1"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
+  - :Section: "About Ada"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
+  - :Section: "Precourse"
+    :Repos:
+    - :Url: https://github.com/ada-developers-academy/ada-precourse-v2  


### PR DESCRIPTION
I made a judgement call to move Lightning Talks down a below PSEs and Projects, since students won't need to open them up quite as much, but happy to move it back if anyone thinks consistency in that ordering is important or something