### PR TITLE
Add internship prep repo

### DIFF
--- a/c19/atlanta/course.yaml
+++ b/c19/atlanta/course.yaml
@@ -42,4 +42,8 @@
   - :Section: "Capstone"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-capstone
+  - :Section: "Internship Prep"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-industry-prep
+
 

--- a/c19/digital/course.yaml
+++ b/c19/digital/course.yaml
@@ -42,5 +42,8 @@
   - :Section: "Capstone"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-capstone
-  
+  - :Section: "Internship Prep"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-industry-prep
+
 

--- a/c19/seattle/course.yaml
+++ b/c19/seattle/course.yaml
@@ -42,4 +42,7 @@
   - :Section: "Capstone"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-capstone
-  
+  - :Section: "Internship Prep"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-industry-prep
+

--- a/course.yaml
+++ b/course.yaml
@@ -57,5 +57,6 @@
   - :Section: "Thursdays at Ada - Mock Interview Retrospectives"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/cs-fun-mock-interviews
-  
-
+  - :Section: "Internship Prep"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-industry-prep


### PR DESCRIPTION
**Summary of Changes**
- Add `core-industry-prep` repo to all C19 and Core cohorts under Internship Prep title so we can publish Amazon courses