### PR TITLE
remove About Ada section from course.yaml after Core Hub port

### DIFF
--- a/course.yaml
+++ b/course.yaml
@@ -3,9 +3,6 @@
   - :Section: "Precourse"
     :Repos:
     - :Url: https://github.com/ada-developers-academy/ada-precourse-v2
-  - :Section: "About Ada"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-about-ada
   - :Section: "Unit 1"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-unit-1


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/1205655776549324/1208012900726979)

This pull request is to remove the "About Ada" section from the `config.yaml` since it was ported to the Core Hub. 