### PR TITLE
Add c23 course config

### DIFF
--- a/c23/course.yaml
+++ b/c23/course.yaml
@@ -1,0 +1,52 @@
+---
+  :Course:
+  - :Section: "Unit 4 - Post-Classroom CS Fundamentals"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/ada-CS-Fundamentals-Internship
+  - :Section: "Unit 4 - Problem Solving Exercises"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/cs-fun-interview-practice
+  - :Section: "Unit 4 - Mock Interview Retrospectives"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/cs-fun-mock-interviews
+  - :Section: "Precourse"
+    :Repos:
+    - :Url: https://github.com/ada-developers-academy/ada-precourse-v2
+  - :Section: "Unit 1"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-unit-1
+  - :Section: "Unit 2"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-unit-2
+  - :Section: "Unit 3"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-unit-3
+  - :Section: "CS Fundamentals"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-cs-fundamentals
+  - :Section: "Software Development Tools"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-software-tools
+  - :Section: "AI Topics"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/independent-ai-topics  
+  - :Section: "Projects"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-projects
+  - :Section: "Problem-Solving Exercises (PSEs)"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-pses
+  - :Section: "Lightning Talks"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
+  - :Section: "Industry Prep"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-industry-career
+  - :Section: "Capstone"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-capstone
+  - :Section: "Internship Prep"
+    :Repos:
+    - :Url: https://github.com/Ada-Developers-Academy/core-industry-prep
+
+

--- a/c23/course.yaml
+++ b/c23/course.yaml
@@ -39,9 +39,6 @@
   - :Section: "Lightning Talks"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-lightning-talks
-  - :Section: "Industry Prep"
-    :Repos:
-    - :Url: https://github.com/Ada-Developers-Academy/core-industry-career
   - :Section: "Capstone"
     :Repos:
     - :Url: https://github.com/Ada-Developers-Academy/core-capstone


### PR DESCRIPTION
Add c23 folder with config.yaml for c23 classes. 

New config removes sections that we have not been revealing for the last few cohorts:
- Social Justice
- Professional & career development
- Industry Prep - The "Algorithm Practice Sessions" we display from `Industry Prep` are also in the `Internship Prep` repo. The` Internship Prep` repo contains the Vim/Linux/Git resources we need for Amazon students, so we can display both from `Internship Prep` and remove `Industry Prep`.

Also removes About Ada section that is now on the core hub site